### PR TITLE
Handle gzipped responses

### DIFF
--- a/armstrong/esi/middleware.py
+++ b/armstrong/esi/middleware.py
@@ -5,8 +5,8 @@ from django.core.urlresolvers import resolve
 from django.core.cache import cache
 from django.http import HttpResponse
 
-from .utils import merge_fragment_headers, merge_fragment_cookies, \
-    replace_esi_tags
+from .utils import replace_esi_tags, gzip_response_content, \
+    gunzip_response_content
 
 
 esi_tag_re = re.compile(r'<esi:include src="(?P<url>[^"]+?)"\s*/>', re.I)
@@ -14,8 +14,26 @@ esi_tag_re = re.compile(r'<esi:include src="(?P<url>[^"]+?)"\s*/>', re.I)
 class IncludeEsiMiddleware(object):
     def process_response(self, request, response):
         esi_status = getattr(response, '_esi', {'used': False})
-        if esi_status['used']:
-            replace_esi_tags(request, response)
+        if not esi_status['used']:
+            return response
+
+        # There is the possibility that GZipMiddleware has already been loaded by
+        # the time we get this.  This is an uncommon case (and one advised against
+        # in Django documentation), but when it happens we need to be able to work.
+        #
+        # Note: Running GZipMiddleware prior to the IncludeEsiMiddleware causes the
+        # response to be compressed, decompressed, and then recompressed again.
+        # Nine times out of ten, this is **not** what you want, but in the rare
+        # instance that it is, this will continue to work as expected.
+        is_gzipped = response.get('Content-Encoding', None) == 'gzip'
+        if is_gzipped:
+            gunzip_response_content(response)
+
+        replace_esi_tags(request, response)
+
+        if is_gzipped:
+            gzip_response_content(request, response)
+
         return response
 
 class StoreEsiStatusMiddleware(object):

--- a/armstrong/esi/tests/esi_support/urls.py
+++ b/armstrong/esi/tests/esi_support/urls.py
@@ -6,4 +6,5 @@ urlpatterns = patterns('armstrong.esi.tests.esi_support.views',
     url(r'^cookies/(?P<number>\d+)/$', 'cookie_view', name='cookie_view'),
     url(r'^last-modified/(?P<timestamp>\d+)/$', 'last_modified', name='last_modified'),
     url(r'^vary/$', 'vary', name='vary'),
+    url(r'^500chars/$', 'text', name='text'),
 )

--- a/armstrong/esi/tests/esi_support/views.py
+++ b/armstrong/esi/tests/esi_support/views.py
@@ -25,3 +25,6 @@ def vary(request):
     response = HttpResponse(request.GET['headers'])
     patch_vary_headers(response, cc_delim_re.split(request.GET['headers']))
     return response
+
+def text(request):
+    return HttpResponse('a' * 500)


### PR DESCRIPTION
Where network bandwidth is a limiting factor, caching gzipped responses
may be desirable. Uncompressing such responses allows the ESI tags to
still be processed correctly, and another GZipMiddleware can be placed
above the IncludeEsiMiddleware to compress the response for serving.
