### PR TITLE
Add a setting to skip processing ESIs on error pages

### DIFF
--- a/armstrong/esi/tests/esi_support/urls.py
+++ b/armstrong/esi/tests/esi_support/urls.py
@@ -7,4 +7,5 @@ urlpatterns = patterns('armstrong.esi.tests.esi_support.views',
     url(r'^last-modified/(?P<timestamp>\d+)/$', 'last_modified', name='last_modified'),
     url(r'^vary/$', 'vary', name='vary'),
     url(r'^500chars/$', 'text', name='text'),
+    url(r'^recursive-404/$', 'recursive_404', name='recursive_404'),
 )

--- a/armstrong/esi/tests/esi_support/views.py
+++ b/armstrong/esi/tests/esi_support/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.cache import cc_delim_re, patch_vary_headers
 from django.utils.http import http_date
 
@@ -28,3 +28,8 @@ def vary(request):
 
 def text(request):
     return HttpResponse('a' * 500)
+
+def recursive_404(request):
+    response = HttpResponseNotFound('<esi:include src="/recursive-404/" />')
+    response._esi = {'used': True}
+    return response

--- a/armstrong/esi/tests/middleware.py
+++ b/armstrong/esi/tests/middleware.py
@@ -257,7 +257,6 @@ class TestMiddleware(TestCase):
         })
 
         result = full_process_response(request, response)
-        # As long as this doesn't raise a RuntimeError due to infinite
-        # recursion, we're ok.
+        self.assertEqual(result.content, '')
 
         restore_settings(*patch_data)

--- a/armstrong/esi/utils.py
+++ b/armstrong/esi/utils.py
@@ -6,6 +6,8 @@ import re
 import time
 from urlparse import urljoin
 
+from django.conf import settings
+from django.http import HttpResponse
 from django.middleware.gzip import GZipMiddleware
 from django.utils.cache import cc_delim_re
 from django.utils.datastructures import MultiValueDict
@@ -115,6 +117,7 @@ def build_full_fragment_url(request, url):
 # TODO: Reduce the lines of codes and varying functionality of this code so its
 #       tests can be reduced in complexity.
 def replace_esi_tags(request, response):
+    process_errors = getattr(settings, 'ESI_PROCESS_ERRORS', False)
     fragment_headers = MultiValueDict()
     fragment_cookies = []
     request_data = {
@@ -126,8 +129,12 @@ def replace_esi_tags(request, response):
     replacement_offset = 0
     for match in esi_tag_re.finditer(response.content):
         url = build_full_fragment_url(request, match.group('url'))
-        client = http_client.Client(**request_data)
-        fragment = client.get(url)
+
+        if response.status_code == 200 or process_errors:
+            client = http_client.Client(**request_data)
+            fragment = client.get(url)
+        else:
+            fragment = HttpResponse()
 
         if fragment.status_code != 200:
             extra = {'data': {


### PR DESCRIPTION
If someone has ESI tags in their base template and their error pages inherit from those, infinite recursion will occur whenever that error happens. This avoids that common case, but limiting ESI recursion depth explicitly may be a good idea in the future.
