### PR TITLE
Add dummy middleware that removes ESI tags from the DOM

### DIFF
--- a/armstrong/esi/middleware.py
+++ b/armstrong/esi/middleware.py
@@ -38,6 +38,7 @@ class IncludeEsiMiddleware(object):
 
 
 class DummyEsiMiddleware(object):
+    """A middleware that comments out ESI tags to remove them from the DOM."""
     def process_response(self, request, response):
         esi_status = getattr(request, '_esi', {'used': False})
         if not esi_status['used']:

--- a/armstrong/esi/middleware.py
+++ b/armstrong/esi/middleware.py
@@ -36,6 +36,33 @@ class IncludeEsiMiddleware(object):
 
         return response
 
+
+class DummyEsiMiddleware(object):
+    def process_response(self, request, response):
+        esi_status = getattr(request, '_esi', {'used': False})
+        if not esi_status['used']:
+            return response
+
+        # There is the possibility that GZipMiddleware has already been loaded by
+        # the time we get this.  This is an uncommon case (and one advised against
+        # in Django documentation), but when it happens we need to be able to work.
+        #
+        # Note: Running GZipMiddleware prior to the IncludeEsiMiddleware causes the
+        # response to be compressed, decompressed, and then recompressed again.
+        # Nine times out of ten, this is **not** what you want, but in the rare
+        # instance that it is, this will continue to work as expected.
+        is_gzipped = response.get('Content-Encoding', None) == 'gzip'
+        if is_gzipped:
+            gunzip_response_content(response)
+
+        replace_esi_tags(request, response)
+
+        if is_gzipped:
+            gzip_response_content(request, response)
+
+        return response
+
+
 class EsiHeaderMiddleware(object):
     def process_response(self, request, response):
         if hasattr(request, '_esi'):

--- a/armstrong/esi/middleware.py
+++ b/armstrong/esi/middleware.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.http import HttpResponse
 
 from .utils import replace_esi_tags, gzip_response_content, \
-    gunzip_response_content
+    gunzip_response_content, dummy_replace_esi_tags
 
 
 esi_tag_re = re.compile(r'<esi:include src="(?P<url>[^"]+?)"\s*/>', re.I)
@@ -55,7 +55,7 @@ class DummyEsiMiddleware(object):
         if is_gzipped:
             gunzip_response_content(response)
 
-        replace_esi_tags(request, response)
+        dummy_replace_esi_tags(request, response)
 
         if is_gzipped:
             gzip_response_content(request, response)

--- a/armstrong/esi/utils.py
+++ b/armstrong/esi/utils.py
@@ -160,3 +160,52 @@ def replace_esi_tags(request, response):
 
     merge_fragment_headers(response, fragment_headers)
     merge_fragment_cookies(response, fragment_cookies)
+
+
+# TODO: Test this independently of the middleware
+# TODO: Reduce the lines of codes and varying functionality of this code so its
+#       tests can be reduced in complexity.
+def dummy_replace_esi_tags(request, response):
+    process_errors = getattr(settings, 'ESI_PROCESS_ERRORS', False)
+    fragment_headers = MultiValueDict()
+    fragment_cookies = []
+    request_data = {
+        'cookies': request.COOKIES,
+        'HTTP_REFERER': request.build_absolute_uri(),
+        'HTTP_X_ESI_FRAGMENT': True,
+    }
+
+    replacement_offset = 0
+    for match in esi_tag_re.finditer(response.content):
+        url = build_full_fragment_url(request, match.group('url'))
+
+        if response.status_code == 200 or process_errors:
+            client = http_client.Client(**request_data)
+            fragment = client.get(url)
+        else:
+            fragment = HttpResponse()
+
+        if fragment.status_code != 200:
+            # Remove the error content so it isn't added to the page.
+            fragment.content = ''
+            extra = {'data': {
+                'fragment': fragment.__dict__,
+                'request': request.__dict__,
+            }}
+            log.error('ESI fragment %s returned status code %s' %
+                (url, fragment.status_code), extra=extra)
+
+        start = match.start() + replacement_offset
+        end = match.end() + replacement_offset
+        response.content = '%s%s%s' % (response.content[:start],
+            fragment.content, response.content[end:])
+        replacement_offset += len(fragment.content) - len(match.group(0))
+
+        for header in HEADERS_TO_MERGE:
+            if header in fragment:
+                fragment_headers.appendlist(header, fragment[header])
+        if fragment.cookies:
+            fragment_cookies.append(fragment.cookies)
+
+    merge_fragment_headers(response, fragment_headers)
+    merge_fragment_cookies(response, fragment_cookies)


### PR DESCRIPTION
Closes #14

Functionality is complete, but missing changes to support.

If `'armstrong.esi.middleware.DummyEsiMiddleware'` is in your `MIDDLEWARE_CLASSES`, esis will be rendered as comments instead of esi tags:

```
    <!--esi:include src="/esi/accounts/analytics/" /-->
```

instead of the rendered esi or the original esi tag:

```
    <esi:include src="/esi/accounts/analytics/" />
```
### RFC

The thought presently occurs that perhaps this should be NullEsiMiddleware instead of DummyEsiMiddleware.
### TODO
- [ ] make sure it works with esi comments (see section 3.7 of http://www.w3.org/TR/esi-lang)
- [ ] Add tests
- [ ] Update documentation
