### PR TITLE
Update to be Django 1.5 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/*
 share/*
 MANIFEST
 dist/
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.tox/
 bin/
+coverage/
 include/*
 lib/*
 src/*

--- a/armstrong/esi/templatetags/esi.py
+++ b/armstrong/esi/templatetags/esi.py
@@ -11,8 +11,20 @@ class EsiTemplateTagError(Exception):
     pass
 
 class EsiNode(URLNode):
-    def __init__(self, *args, **kwargs):
-        super(EsiNode, self).__init__(*args, **kwargs)
+    def __init__(self, view_name, *args, **kwargs):
+        # Compatibility with Django 1.5 and later
+        if hasattr(view_name, 'token'):
+            try:
+                unescape_string_literal(view_name.token)
+            except ValueError:
+                # If we cannot unescape the token then it is not quoted.
+                # We have to cancel the variables's lookups and tell it
+                # that it has a literal value.
+                view_name.var.lookups = None
+                view_name.var.literal = view_name.token
+
+        super(EsiNode, self).__init__(view_name, *args, **kwargs)
+
         if '/' in str(self.view_name):
             # An actual URL has been passed instead of a view name.
             self.raw_url = unescape_string_literal(str(self.view_name))

--- a/armstrong/esi/templatetags/esi.py
+++ b/armstrong/esi/templatetags/esi.py
@@ -14,7 +14,7 @@ class EsiNode(URLNode):
         super(EsiNode, self).__init__(*args, **kwargs)
         if '/' in str(self.view_name):
             # An actual URL has been passed instead of a view name.
-            self.raw_url = self.view_name
+            self.raw_url = str(self.view_name)
             self.view_name = None
         else:
             self.raw_url = None

--- a/armstrong/esi/templatetags/esi.py
+++ b/armstrong/esi/templatetags/esi.py
@@ -1,6 +1,7 @@
 from django import template
 from django.template import defaulttags
 from django.template.defaulttags import URLNode
+from django.utils.text import unescape_string_literal
 
 
 register = template.Library()
@@ -14,7 +15,7 @@ class EsiNode(URLNode):
         super(EsiNode, self).__init__(*args, **kwargs)
         if '/' in str(self.view_name):
             # An actual URL has been passed instead of a view name.
-            self.raw_url = str(self.view_name)
+            self.raw_url = unescape_string_literal(str(self.view_name))
             self.view_name = None
         else:
             self.raw_url = None

--- a/armstrong/esi/templatetags/esi.py
+++ b/armstrong/esi/templatetags/esi.py
@@ -12,7 +12,7 @@ class EsiTemplateTagError(Exception):
 class EsiNode(URLNode):
     def __init__(self, *args, **kwargs):
         super(EsiNode, self).__init__(*args, **kwargs)
-        if '/' in self.view_name:
+        if '/' in str(self.view_name):
             # An actual URL has been passed instead of a view name.
             self.raw_url = self.view_name
             self.view_name = None

--- a/armstrong/esi/tests/templatetags/esi.py
+++ b/armstrong/esi/tests/templatetags/esi.py
@@ -61,8 +61,8 @@ class TestOfEsiHandler(TestCase):
         token.expects('split_contents').returns(('esi', random_view_name))
         fudge.clear_calls()
 
-        result = esi(None, token)
-        self.assertEquals(result.view_name, random_view_name)
+        result = esi(Parser([]), token)
+        self.assertEquals(str(result.view_name), random_view_name)
 
         fudge.verify()
 

--- a/armstrong/esi/tests/templatetags/esi.py
+++ b/armstrong/esi/tests/templatetags/esi.py
@@ -74,7 +74,8 @@ class TestOfEsiHandler(TestCase):
     def test_can_be_rendered_from_a_template(self):
         raw_template = """
         {% load esi %}
-        {% esi hello_world %}
+        {% load url from future %}
+        {% esi "hello_world" %}
         """
 
         t = template.Template(raw_template)

--- a/armstrong/esi/tests/templatetags/esi.py
+++ b/armstrong/esi/tests/templatetags/esi.py
@@ -1,6 +1,7 @@
 from django import template
 from django.core.urlresolvers import reverse
 from django.template import Token, Parser, TOKEN_BLOCK
+from django.template import FilterExpression
 import fudge
 import random
 
@@ -22,7 +23,7 @@ def create_token(content):
 class TestOfEsiNode(TestCase):
     def test_renders_actual_code(self):
         context = create_context()
-        node = esi(Parser([]), create_token('esi hello_world'))
+        node = esi(Parser([]), create_token('esi "hello_world"'))
         result = node.render(context)
 
         expected_url = reverse('hello_world')
@@ -39,7 +40,7 @@ class TestOfEsiNode(TestCase):
     def test_renders_kwargs(self):
         context = create_context()
         number = random.randint(100, 200)
-        node = esi(Parser([]), create_token('esi hello_number number=%s' % number))
+        node = esi(Parser([]), create_token('esi "hello_number" number=%s' % number))
         result = node.render(context)
 
         expected_url = reverse('hello_number', kwargs={'number': number})
@@ -47,7 +48,8 @@ class TestOfEsiNode(TestCase):
 
     def test_sets_esi_used_to_true_on_context(self):
         context = create_context()
-        node = EsiNode('hello_world', [], {}, None)
+        view_name = FilterExpression('"hello_world"', Parser([]))
+        node = EsiNode(view_name, [], {}, None)
         node.render(context)
 
         self.assertTrue(context['_esi']['used'])

--- a/armstrong/esi/tests/templatetags/esi.py
+++ b/armstrong/esi/tests/templatetags/esi.py
@@ -31,7 +31,7 @@ class TestOfEsiNode(TestCase):
 
     def test_renders_relative_esi(self):
         context = create_context()
-        node = esi(Parser([]), create_token('esi ./blah/'))
+        node = esi(Parser([]), create_token('esi "./blah/"'))
         result = node.render(context)
 
         expected_url = './blah/'

--- a/armstrong/esi/tests/templatetags/esi.py
+++ b/armstrong/esi/tests/templatetags/esi.py
@@ -96,3 +96,15 @@ class TestOfEsiHandler(TestCase):
         result = t.render(context).strip()
         expected_url = reverse('hello_world')
         self.assertEquals(result, '<esi:include src="%s" />' % expected_url)
+
+    def test_can_be_rendered_using_old_url_syntax(self):
+        raw_template = """
+        {% load esi %}
+        {% esi hello_world %}
+        """
+
+        t = template.Template(raw_template)
+        context = create_context()
+        result = t.render(context).strip()
+        expected_url = reverse('hello_world')
+        self.assertEquals(result, '<esi:include src="%s" />' % expected_url)

--- a/package.json
+++ b/package.json
@@ -2,8 +2,5 @@
     "name": "armstrong.esi",
     "version": "1.1.0alpha.0",
     "description": "Utilities to help development of sites that utilize Edge Side Includes",
-    "install_requires": [
-      "Django>=1.3.1,<1.5",
-      "setuptools"
-    ]
+    "install_requires": []
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,1 +1,2 @@
 armstrong.dev>=1.4.0
+tox==1.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = django13, django14, django15
-downloadcache = {envtmpdir}/.cache
+downloadcache = {toxworkdir}/.cache
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = django14, django15
+downloadcache = {envtmpdir}/.cache
+
+[testenv]
+commands =
+    fab test
+
+[testenv:django14]
+deps =
+    -r{toxinidir}/requirements/dev.txt
+    django>=1.4,<1.5
+
+[testenv:django15]
+deps =
+    -r{toxinidir}/requirements/dev.txt
+    django>=1.5,<1.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,15 @@
 [tox]
-envlist = django14, django15
+envlist = django13, django14, django15
 downloadcache = {envtmpdir}/.cache
 
 [testenv]
 commands =
     fab test
+
+[testenv:django13]
+deps =
+    -r{toxinidir}/requirements/dev.txt
+    django>=1.3,<1.4
 
 [testenv:django14]
 deps =


### PR DESCRIPTION
This has the fixes I found were necessary to get armstrong.esi working in a Django 1.5 project. This is backwards compatible and **preserves** Django 1.4 compatibility.

Note: I took Django out of package.json's `install_requires` because we talked about doing that a long time ago in a distant galaxy.
I also took out setuptools. That's technically out of the scope of this PR so I can put it back in. But I don't think distutils doesn't even supports `install_requires`, so you would need something like setuptools to even parse it.

Testing:

```
$ pip install -r requirements/dev.txt
$ tox
```
