### PR TITLE
Fixes my install problem.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup_kwargs = {
     "author": "Bay Citizen & Texas Tribune",
     "author_email": "dev@armstrongcms.org",
     "url": "http://github.com/armstrong/%s/" % info["name"],
-    "packages": packages,
+    "packages": packages + ['armstrong'],
     "package_data": {info["name"]: data_files, },
     "namespace_packages": NAMESPACE_PACKAGES,
     "classifiers": [


### PR DESCRIPTION
To reproduce:

```
  git clone <this repo>

  virtualenv env
  source env/bin/activate
  python setup.py install
  cd ~/ (or anywhere the module won't be on the current path)

  python

  > import armstrong.esi
```

Will fail, as the `__init__.py` isn't installed.

I think you all know this namespace packaging stuff better than I do, so please let me know if there's a better solution here!
